### PR TITLE
[HOPSWORKS-831] [ePipe] Use Uint64 as the processing index instead of…

### DIFF
--- a/include/ElasticSearchBase.h
+++ b/include/ElasticSearchBase.h
@@ -61,7 +61,7 @@ static const char* getStr(HttpOp op) {
 
 template<typename Keys>
 struct Bulk {
-  long mProcessingIndex;
+  Uint64 mProcessingIndex;
   string mJSON;
   vector<ptime> mArrivalTimes;
   ptime mStartProcessing;

--- a/include/NdbDataReader.h
+++ b/include/NdbDataReader.h
@@ -41,11 +41,11 @@ class DataReaderOutHandler{
 template<typename Data>
 struct IndexedDataBatch{
   vector<Data>* mDataBatch;
-  long mIndex;
+  Uint64 mIndex;
   IndexedDataBatch(){
     
   }
-  IndexedDataBatch(long index, vector<Data>* data){
+  IndexedDataBatch(Uint64 index, vector<Data>* data){
    mIndex = index;
    mDataBatch = data;
   }
@@ -56,7 +56,7 @@ class NdbDataReader {
 public:
   NdbDataReader(Conn connection, const bool hopsworks);
   void start(int readerId, DataReaderOutHandler<Keys>* outHandler);
-  void processBatch(long index, vector<Data>* data_batch);
+  void processBatch(Uint64 index, vector<Data>* data_batch);
   virtual ~NdbDataReader();
   
 protected:
@@ -115,7 +115,7 @@ void NdbDataReader<Data, Conn, Keys>::run() {
 }
 
 template<typename Data, typename Conn, typename Keys>
-void NdbDataReader<Data, Conn, Keys>::processBatch(long index, vector<Data>* data_batch) {
+void NdbDataReader<Data, Conn, Keys>::processBatch(Uint64 index, vector<Data>* data_batch) {
   mBatchedQueue->push(IndexedDataBatch<Data>(index, data_batch));
   LOG_DEBUG("Reader-" << mReaderId << ": Process batch " << index);
 }

--- a/include/NdbDataReaders.h
+++ b/include/NdbDataReaders.h
@@ -28,7 +28,7 @@
 #include "ConcurrentPriorityQueue.h"
 #include <boost/atomic.hpp>
 
-typedef boost::atomic<unsigned long> AtomicLong;
+typedef boost::atomic<Uint64> AtomicLong;
 
 template<typename Keys>
 struct BulkIndexComparator {


### PR DESCRIPTION
… long