### PR TITLE
[HOPSWORKS-1712] provenance views - check inodes existance -> no inode -> no view

### DIFF
--- a/include/FileProvenanceElasticDataReader.h
+++ b/include/FileProvenanceElasticDataReader.h
@@ -29,7 +29,12 @@
 #include "FileProvenanceConstants.h"
 #include "FileProvenanceElastic.h"
 
-typedef boost::tuple<std::list<std::string>, FileProvenancePK, boost::optional<FPXAttrBufferPK> > ProcessRowResult;
+struct ProcessRowResult {
+  std::list<std::string> mElasticOps;
+  FileProvenancePK mLogPK;
+  boost::optional<FPXAttrBufferPK> mCompanionPK;
+  FileProvenanceConstants::Operation mProvOp;
+};
 
 class FileProvenanceElasticDataReader : public NdbDataReader<FileProvenanceRow, SConn> {
 public:
@@ -43,9 +48,13 @@ private:
   INodeTable inodesTable;
 
   void processAddedandDeleted(Pq* data_batch, eBulk& bulk);
+  ProcessRowResult rowResult(std::list<std::string> elasticOps, FileProvenancePK logPK,
+          boost::optional<FPXAttrBufferPK> companionPK, FileProvenanceConstants::Operation provOp);
   ProcessRowResult process_row(FileProvenanceRow row);
   FPXAttrBufferRow readBufferedXAttr(FPXAttrBufferPK xattrBufferKey);
   boost::optional<FPXAttrBufferRow> getProvCore(FPXAttrVersionsK versionsKey);
+  ULSet getViewInodes(Pq* data_batch);
+  std::string getElasticBulkOps(std::list <std::string> bulkOps);
 };
 
 class FileProvenanceElasticDataReaders :  public NdbDataReaders<FileProvenanceRow, SConn>{

--- a/include/tables/DBTableBase.h
+++ b/include/tables/DBTableBase.h
@@ -95,7 +95,11 @@ protected:
   }
 
   const NdbDictionary::Index* getIndex(const NdbDictionary::Dictionary* database, const std::string& index_name) {
-    const NdbDictionary::Index* index = database->getIndex(index_name.c_str(), getName().c_str());
+    return getIndex(database, index_name, getName());
+  }
+  const NdbDictionary::Index* getIndex(const NdbDictionary::Dictionary* database, const std::string& index_name,
+          const std::string& table_name) {
+    const NdbDictionary::Index* index = database->getIndex(index_name.c_str(), table_name.c_str());
     if (!index) {
       LOG_ERROR("index:" << index_name << " error");
       LOG_NDB_API_ERROR(database->getNdbError());

--- a/include/tables/INodeTable.h
+++ b/include/tables/INodeTable.h
@@ -289,6 +289,11 @@ public:
     return DBTable<INodeRow>::doRead(connection, a);
   }
 
+  INodeVec get(Ndb* connection, AnyVec& pks){
+    INodeVec inodes = doRead(connection, pks);
+    return inodes;
+  }
+
   INodeMap get(Ndb* connection, Fmq* data_batch) {
     AnyVec anyVec;
     boost::unordered_map<Int64, FsMutationRow> mutationsByInode;


### PR DESCRIPTION
For inode operations that target a provenance view - a document in elastic, check for the existance on inode before doing a change to elastic. A elastic document (provenance view) should have a inode in file system.
If the inode is not there, it means current operation is late and we can just drop it, or maybe from a retry operation.
Also if we are trying to do a script operation (xattr change) on a non existing elastic document, we will get an elastic exception. So better check that the inode exists - so the view exists.