### PR TITLE
[HOPSWORKS-1800] cache provenance-epipe scan operations

### DIFF
--- a/config.ini.template
+++ b/config.ini.template
@@ -12,6 +12,8 @@ meta_database = hopsworks
 hive_meta_database = metastore
 poll_maxTimeToWait = 2000
 lru_cap = 10000
+prov_file_lru_cap = 10000
+prov_core_lru_cap = 100
 recovery = false
 
 # log level trace=0, debug=1, info=2, warn=3, error=4, fatal=5

--- a/include/FileProvenanceConstants.h
+++ b/include/FileProvenanceConstants.h
@@ -20,12 +20,11 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/assign.hpp>
 #include "tables/FileProvenanceLogTable.h"
+#include "FileProvenanceConstantsRaw.h"
 
 namespace FileProvenanceConstants {
 
-  const Int8 XATTRS_USER_NAMESPACE = 5;
   const std::string README_FILE = "README.md";
   
   const std::string TYPE_NONE = "NONE";
@@ -44,7 +43,6 @@ namespace FileProvenanceConstants {
 
   const std::string XATTR = "xattr_prov";
 
-  const std::string XATTR_PROV_CORE = "core";
   const std::string XATTR_PROJECT_IID = "project_iid"; //part of project core
 
   const std::string PROV_TYPE_STORE_NONE = "NONE";
@@ -104,51 +102,10 @@ namespace FileProvenanceConstants {
     }
   };
 
-  const std::string H_OP_CREATE = "CREATE";
-  const std::string H_OP_DELETE = "DELETE";
-  const std::string H_OP_ACCESS_DATA = "ACCESS_DATA";
-  const std::string H_OP_MODIFY_DATA = "MODIFY_DATA";
-  const std::string H_OP_METADATA = "METADATA";
-  const std::string H_OP_XATTR_ADD = "XATTR_ADD";
-  const std::string H_OP_XATTR_UPDATE = "XATTR_UPDATE";
-  const std::string H_OP_XATTR_DELETE = "XATTR_DELETE";
-  const std::string H_OP_OTHER = "OTHER";
-
   const std::string ELASTIC_NOP = "\n";
   const std::string ELASTIC_NOP2 = "\n\n";
 
-  enum Operation {
-    OP_CREATE,
-    OP_DELETE,
-    OP_ACCESS_DATA,
-    OP_MODIFY_DATA,
-    OP_XATTR_ADD,
-    OP_XATTR_UPDATE,
-    OP_XATTR_DELETE,
-    OP_METADATA,
-    OP_OTHER
-  };
 
-  const boost::unordered_map<std::string, Operation> ops = boost::assign::map_list_of
-      (H_OP_CREATE, OP_CREATE)
-      (H_OP_DELETE, OP_DELETE)
-      (H_OP_ACCESS_DATA, OP_ACCESS_DATA)
-      (H_OP_MODIFY_DATA, OP_MODIFY_DATA)
-      (H_OP_XATTR_ADD, OP_XATTR_ADD)
-      (H_OP_XATTR_UPDATE, OP_XATTR_UPDATE)
-      (H_OP_XATTR_DELETE, OP_XATTR_DELETE)
-      (H_OP_METADATA, OP_METADATA)
-      (H_OP_OTHER, OP_OTHER);
-
-  inline Operation findOp(const FileProvenanceRow row) {
-    if(ops.find(row.mOperation) == ops.end()) {
-      LOG_WARN("no such operation:" << row.mOperation);
-      std::stringstream cause;
-      cause << "no such operation:" << row.mOperation;
-      throw std::logic_error(cause.str());
-    }
-    return ops.at(row.mOperation);
-  }
   const std::string APP_SUBMITTED_STATE = "SUBMITTED";
   const std::string APP_RUNNING_STATE = "RUNNING";
 

--- a/include/FileProvenanceConstantsRaw.h
+++ b/include/FileProvenanceConstantsRaw.h
@@ -1,0 +1,53 @@
+#ifndef EPIPE_FILEPROVENANCECONSTANTSRAW_H
+#define EPIPE_FILEPROVENANCECONSTANTSRAW_H
+
+#include <boost/assign.hpp>
+
+namespace FileProvenanceConstantsRaw {
+  const Int8 XATTRS_USER_NAMESPACE = 5;
+  const std::string XATTR_PROV_CORE = "core";
+
+  const std::string H_OP_CREATE = "CREATE";
+  const std::string H_OP_DELETE = "DELETE";
+  const std::string H_OP_ACCESS_DATA = "ACCESS_DATA";
+  const std::string H_OP_MODIFY_DATA = "MODIFY_DATA";
+  const std::string H_OP_METADATA = "METADATA";
+  const std::string H_OP_XATTR_ADD = "XATTR_ADD";
+  const std::string H_OP_XATTR_UPDATE = "XATTR_UPDATE";
+  const std::string H_OP_XATTR_DELETE = "XATTR_DELETE";
+  const std::string H_OP_OTHER = "OTHER";
+
+  enum Operation {
+    OP_CREATE,
+    OP_DELETE,
+    OP_ACCESS_DATA,
+    OP_MODIFY_DATA,
+    OP_XATTR_ADD,
+    OP_XATTR_UPDATE,
+    OP_XATTR_DELETE,
+    OP_METADATA,
+    OP_OTHER
+  };
+
+  const boost::unordered_map<std::string, Operation> ops = boost::assign::map_list_of
+          (H_OP_CREATE, OP_CREATE)
+          (H_OP_DELETE, OP_DELETE)
+          (H_OP_ACCESS_DATA, OP_ACCESS_DATA)
+          (H_OP_MODIFY_DATA, OP_MODIFY_DATA)
+          (H_OP_XATTR_ADD, OP_XATTR_ADD)
+          (H_OP_XATTR_UPDATE, OP_XATTR_UPDATE)
+          (H_OP_XATTR_DELETE, OP_XATTR_DELETE)
+          (H_OP_METADATA, OP_METADATA)
+          (H_OP_OTHER, OP_OTHER);
+
+  inline Operation findOp(std::string operation) {
+    if(ops.find(operation) == ops.end()) {
+      std::stringstream cause;
+      cause << "no such operation:" << operation;
+      LOG_WARN(cause.str());
+      throw std::logic_error(cause.str());
+    }
+    return ops.at(operation);
+  }
+}
+#endif //EPIPE_FILEPROVENANCECONSTANTSRAW_H

--- a/include/FileProvenanceElastic.h
+++ b/include/FileProvenanceElastic.h
@@ -26,11 +26,12 @@
 class FileProvenanceElastic : public ElasticSearchBase {
 public:
   FileProvenanceElastic(const HttpClientConfig elastic_client_config,int time_to_wait_before_inserting, int bulk_size,
-      const bool stats, SConn conn);
+      const bool stats, SConn conn, int file_lru_cap, int xattr_lru_cap);
 
   virtual ~FileProvenanceElastic();
 private:
   SConn mConn;
+  FileProvenanceLogTable mFileProvTable;
 
   void intProcessOneByOne(eBulk bulk);
   bool intProcessBatch(std::string val, std::vector<eBulk>* bulks, std::vector<const LogHandler*> cleanupHandlers, ptime start_time);

--- a/include/FileProvenanceTableTailer.h
+++ b/include/FileProvenanceTableTailer.h
@@ -25,7 +25,7 @@
 
 class FileProvenanceTableTailer : public RCTableTailer<FileProvenanceRow> {
 public:
-  FileProvenanceTableTailer(Ndb* ndb, Ndb* ndbRecovery, const int poll_maxTimeToWait, const Barrier barrier);
+  FileProvenanceTableTailer(Ndb* ndb, Ndb* ndbRecovery, const int poll_maxTimeToWait, const Barrier barrier, int prov_file_lru_cap, int prov_core_lru_ca);
   FileProvenanceRow consume();
   virtual ~FileProvenanceTableTailer();
 

--- a/include/Notifier.h
+++ b/include/Notifier.h
@@ -46,7 +46,8 @@ public:
           const int poll_maxTimeToWait, const HttpClientConfig elastic_client_config, const bool hopsworks,
           const std::string elastic_search_index, const std::string elastic_featurestore_index,
           const std::string elastic_app_provenance_index,
-          const int elastic_batch_size, const int elastic_issue_time, const int lru_cap, const bool recovery, const bool stats,
+          const int elastic_batch_size, const int elastic_issue_time,
+          const int lru_cap, const int prov_file_lru_cap, const int prov_core_lru_cap, const bool recovery, const bool stats,
           Barrier barrier, const bool hiveCleaner, const std::string
           metricsServer);
   void start();
@@ -68,6 +69,8 @@ private:
   const int mElasticBatchsize;
   const int mElasticIssueTime;
   const int mLRUCap;
+  const int mProvFileLRUCap;
+  const int mProvCoreLRUCap;
   const bool mRecovery;
   const bool mStats;
   const Barrier mBarrier;

--- a/include/TimedRestBatcher.h
+++ b/include/TimedRestBatcher.h
@@ -198,6 +198,12 @@ private:
 
 };
 
+struct ParsingResponse{
+  bool mSuccess;
+  bool mRetryable;
+  std::string errorMsg;
+};
+
 class TimedRestBatcher : public Batcher {
 public:
   TimedRestBatcher(const HttpClientConfig elastic_client_config, int time_to_wait_before_inserting, int bulk_size);
@@ -213,15 +219,10 @@ protected:
   ptime mTimeElasticConnectionFailed;
   Uint32 mCurrentQueueSize;
 
-  bool httpPostRequest(std::string requestUrl, std::string json);
-  bool httpDeleteRequest(std::string requestUrl);
+  ParsingResponse httpPostRequest(std::string requestUrl, std::string json);
+  ParsingResponse httpDeleteRequest(std::string requestUrl);
 
   virtual void process(std::vector<eBulk>* data) = 0;
-
-  struct ParsingResponse{
-    bool mSuccess;
-    bool mRetryable;
-  };
 
   virtual ParsingResponse parseResponse(std::string response) = 0;
 
@@ -242,8 +243,7 @@ private:
     DELETE
   };
 
-  bool handleHttpRequestWithRetry(HttpVerb verb,std::string
-  requestUrl, std::string json);
+  ParsingResponse handleHttpRequestWithRetry(HttpVerb verb, std::string requestUrl, std::string json);
 
 };
 #endif //TIMEDRESTBATCHER_H

--- a/include/tables/DBTable.h
+++ b/include/tables/DBTable.h
@@ -35,7 +35,7 @@ template<typename TableRow>
 class DBTable : public DBTableBase {
 public:
   DBTable(const std::string table);
-  DBTable(const std::string table, const DBTableBase* companionTableBase);
+  DBTable(const std::string table, DBTableBase* companionTableBase);
 
   void getAll(Ndb* connection);
   bool next();
@@ -55,7 +55,7 @@ private:
   NdbTransaction* mCurrentTransaction;
   NdbOperation* mCurrentOperation;
   NdbRecAttr** mCurrentRow;
-  const DBTableBase* mCompanionTableBase;
+
   const NdbDictionary::Table* mCompanionTable;
 
   void close();
@@ -63,6 +63,8 @@ private:
   void applyConditionOnOperationOnCompanion(NdbOperation* operation, AnyMap& any);
   
 protected:
+  DBTableBase* mCompanionTableBase;
+
   NdbRecAttr** getColumnValues(NdbOperation* op);
   void start(Ndb* connection);
   void start(Ndb* connection, boost::optional<Int64> partitionId);
@@ -101,7 +103,7 @@ DBTable<TableRow>::DBTable(const std::string table)
 }
 
 template<typename TableRow>
-DBTable<TableRow>::DBTable(const std::string table, const DBTableBase* companionTableBase)
+DBTable<TableRow>::DBTable(const std::string table, DBTableBase* companionTableBase)
     : DBTableBase(table), mReadEpoch(false), mCompanionTableBase(companionTableBase) {
 }
 
@@ -110,7 +112,6 @@ void DBTable<TableRow>::setReadEpoch(bool readEpoch) {
   mReadEpoch = readEpoch;
   LOG_DEBUG(getName() << " -- ReadEpoch : " << mReadEpoch);
 }
-
 template<typename TableRow>
 NdbRecAttr** DBTable<TableRow>::getColumnValues(NdbOperation* op) {
   int numCols = mReadEpoch ? getNoColumns() + 1 : getNoColumns();

--- a/include/tables/DBWatchTable.h
+++ b/include/tables/DBWatchTable.h
@@ -50,7 +50,7 @@ template<typename TableRow>
 class DBWatchTable : public DBTable<TableRow> {
 public:
   DBWatchTable(const std::string table);
-  DBWatchTable(const std::string table, const DBTableBase* companionTable);
+  DBWatchTable(const std::string table, DBTableBase* companionTable);
   evtvec_size_type getNoEvents() const;
   NdbDictionary::Event::TableEvent getEvent(evtvec_size_type index) const;
   EpochsRowsMap<TableRow> getAllForRecovery(Ndb* connection);
@@ -73,7 +73,7 @@ DBWatchTable<TableRow>::DBWatchTable(const std::string table) : DBTable<TableRow
 }
 
 template<typename TableRow>
-DBWatchTable<TableRow>::DBWatchTable(const std::string table, const DBTableBase* companionTable) :
+DBWatchTable<TableRow>::DBWatchTable(const std::string table, DBTableBase* companionTable) :
 DBTable<TableRow>(table, companionTable) {
 }
 

--- a/src/AppProvenanceElastic.cpp
+++ b/src/AppProvenanceElastic.cpp
@@ -37,7 +37,7 @@ void AppProvenanceElastic::process(std::vector<eBulk>* bulks) {
   }
 
   ptime start_time = Utils::getCurrentTime();
-  if (httpPostRequest(mElasticBulkAddr, batch)) {
+  if (httpPostRequest(mElasticBulkAddr, batch).mSuccess) {
     AppProvenanceLogTable().removeLogs(mConn, logRHandlers);
     if (mStats) {
       mCounters->bulksProcessed(start_time, bulks);
@@ -47,7 +47,7 @@ void AppProvenanceElastic::process(std::vector<eBulk>* bulks) {
       eBulk bulk = *it;
       for(eEvent event : bulk.mEvents){
         if(!bulkRequest(event)){
-          LOG_FATAL("Failure while processing log : "
+          LOG_FATAL("app prov - elastic failure while processing log : "
           << event.getLogHandler()->getDescription() << std::endl << event.getJSON());
         }
       }
@@ -59,7 +59,7 @@ void AppProvenanceElastic::process(std::vector<eBulk>* bulks) {
 }
 
 bool AppProvenanceElastic::bulkRequest(eEvent& event) {
-  if (httpPostRequest(mElasticBulkAddr, event.getJSON())){
+  if (httpPostRequest(mElasticBulkAddr, event.getJSON()).mSuccess){
     event.getLogHandler()->removeLog(mConn);
     return true;
   }

--- a/src/AppProvenanceElasticDataReader.cpp
+++ b/src/AppProvenanceElasticDataReader.cpp
@@ -23,7 +23,7 @@ AppProvenanceElasticDataReader::AppProvenanceElasticDataReader(SConn connection,
 class Helper {
 public:
   static std::list<std::string> process_row(AppProvenanceRow row) {
-    LOG_INFO("app provenance:" << row.to_string());
+    LOG_DEBUG("app prov - processing:" << row.getPK().to_string());
     std::list<std::string> bulkOps;
 
     if(row.mFinishTime != 0) {
@@ -79,6 +79,7 @@ public:
     
     std::stringstream out;
     out << opBuffer.GetString() << std::endl << dataBuffer.GetString();
+    LOG_TRACE("app prov - elastic - add:" << out.str());
     return out.str();
   }
 

--- a/src/AppProvenanceTableTailer.cpp
+++ b/src/AppProvenanceTableTailer.cpp
@@ -29,7 +29,7 @@ void AppProvenanceTableTailer::handleEvent(NdbDictionary::Event::TableEvent even
   int size = mCurrentPriorityQueue->size();
   mLock.unlock();
 
-  LOG_TRACE("push provenance log for [" << row.mId << "] to queue[" << size << "]");
+  LOG_TRACE("app prov - push provenance log for [" << row.mId << "] to queue[" << size << "]");
 
 }
 
@@ -43,7 +43,7 @@ void AppProvenanceTableTailer::barrierChanged() {
   mLock.unlock();
 
   if (pq != NULL) {
-    LOG_TRACE("--------------------------------------NEW BARRIER (" << pq->size() << " events )------------------- ");
+    LOG_TRACE("app prov --------------------------------------NEW BARRIER (" << pq->size() << " events )------------------- ");
     pushToQueue(pq);
   }
 }
@@ -51,7 +51,7 @@ void AppProvenanceTableTailer::barrierChanged() {
 AppProvenanceRow AppProvenanceTableTailer::consume() {
   AppProvenanceRow row;
   mQueue->wait_and_pop(row);
-  LOG_TRACE(" pop appid [" << row.mId << "] from queue \n" << row.to_string());
+  LOG_TRACE("app prov - pop appid [" << row.mId << "] from queue \n" << row.to_string());
   return row;
 }
 

--- a/src/ElasticSearchBase.cpp
+++ b/src/ElasticSearchBase.cpp
@@ -37,8 +37,8 @@ std::string ElasticSearchBase::getElasticSearchBulkUrl() {
   return str;
 }
 
-TimedRestBatcher::ParsingResponse ElasticSearchBase::parseResponse(std::string response) {
-  ParsingResponse pr = {false, false};
+ParsingResponse ElasticSearchBase::parseResponse(std::string response) {
+  ParsingResponse pr = {false, false, ""};
   try {
     LOG_DEBUG("ES Response: \n" << response);
     if(response == "Open Distro Security not initialized."){
@@ -71,7 +71,8 @@ TimedRestBatcher::ParsingResponse ElasticSearchBase::parseResponse(std::string r
             }
           }
           std::string errorsStr = errors.str();
-          LOG_ERROR(" ES got errors: " << errorsStr);
+          LOG_ERROR("ES got errors: " << errorsStr);
+          pr.errorMsg = errorsStr;
           return pr;
         }
       } else if (d.HasMember("error")) {
@@ -80,8 +81,12 @@ TimedRestBatcher::ParsingResponse ElasticSearchBase::parseResponse(std::string r
           const rapidjson::Value & errorType = error["type"];
           const rapidjson::Value & errorReason = error["reason"];
           LOG_ERROR(" ES got error: " << errorType.GetString() << ":" << errorReason.GetString());
+          std::stringstream errorS;
+          errorS << errorType.GetString() << ":" << errorReason.GetString();
+          pr.errorMsg = errorS.str();
         } else if (error.IsString()) {
           LOG_ERROR(" ES got error: " << error.GetString());
+          pr.errorMsg = error.GetString();
         }
         return pr;
       }

--- a/src/ProjectsElasticSearch.cpp
+++ b/src/ProjectsElasticSearch.cpp
@@ -50,7 +50,7 @@ void ProjectsElasticSearch::process(std::vector<eBulk>* bulks) {
   }
 
   ptime start_time = Utils::getCurrentTime();
-  if (httpPostRequest(mElasticBulkAddr, batch)) {
+  if (httpPostRequest(mElasticBulkAddr, batch).mSuccess) {
     if (metalogs > 0) {
       MetadataLogTable().removeLogs(mConn.metadataConnection, logRHandlers);
     }
@@ -84,7 +84,7 @@ void ProjectsElasticSearch::process(std::vector<eBulk>* bulks) {
 
 
 bool ProjectsElasticSearch::bulkRequest(eEvent& event) {
-  if (httpPostRequest(mElasticBulkAddr, event.getJSON())){
+  if (httpPostRequest(mElasticBulkAddr, event.getJSON()).mSuccess){
     if(event.getLogHandler()->getType() == LogType::FSLOG){
       event.getLogHandler()->removeLog(mConn.inodeConnection);
     }else if(event.getLogHandler()->getType() == LogType::METALOG || event.getLogHandler()->getType() == LogType::HOPSWORKSLOG){

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,8 @@ int main(int argc, char** argv) {
     std::string elastic_app_provenance_index = "appprovenance";
 
     int lru_cap = DEFAULT_MAX_CAPACITY;
+    int prov_file_lru_cap = DEFAULT_MAX_CAPACITY;
+    int prov_core_lru_cap = 100;
     bool recovery = true;
     bool stats = true;
 
@@ -123,8 +125,9 @@ int main(int argc, char** argv) {
         ("ewait_time",
          po::value<int>(&elastic_issue_time)->default_value(elastic_issue_time),
          "time to wait in miliseconds before issuing a bulk request to Elasticsearch if the batch size wasn't reached")
-        ("lru_cap", po::value<int>(&lru_cap)->default_value(lru_cap),
-         "LRU Cache max capacity")
+        ("lru_cap", po::value<int>(&lru_cap)->default_value(lru_cap), "LRU Cache max capacity")
+        ("prov_file_lru_cap", po::value<int>(&prov_file_lru_cap)->default_value(prov_file_lru_cap), "Prov File LRU Cache max capacity")
+        ("prov_core_lru_cap", po::value<int>(&prov_core_lru_cap)->default_value(prov_core_lru_cap), "Prov Core LRU Cache max capacity")
         ("recovery", po::value<bool>(&recovery)->default_value(recovery),
          "enable or disable startup recovery")
         ("stats", po::value<bool>(&stats)->default_value(stats),
@@ -254,9 +257,9 @@ int main(int argc, char** argv) {
                                        hopsworks, elastic_index, elastic_featurestore_index,
                                        elastic_app_provenance_index,
                                        elastic_batch_size, elastic_issue_time,
-                                       lru_cap, recovery, stats, barrier,
-                                       hiveCleaner,
-                                       metricsServer);
+                                       lru_cap, prov_file_lru_cap, prov_core_lru_cap,
+                                       recovery, stats, barrier,
+                                       hiveCleaner, metricsServer);
       notifer->start();
     }
     return EXIT_SUCCESS;


### PR DESCRIPTION
fixes three issues:
1. datasets have a prov-core xattr used for determining provenance granularity. It is a ndb scan operation in order to get the proper prov-core. We cache it.
2. we check parent projects for operations - if project is deleted we can skip the operation. Checking if a project exists based on inodeId is a scan operation. We cache the project existance for 1h. 
3. hopsworks cleans indices for deleted projects. XAttr operations are script operations which are sensitive to document missing (exception). For delete xattr we allow the exception to occur, recover and skip operation. For add/update if document is missing we insert an empty document on which the script can run.